### PR TITLE
Fix: CROS Allow-origin 주소 추가

### DIFF
--- a/src/main/java/com/example/welperback/global/config/WebConfig.java
+++ b/src/main/java/com/example/welperback/global/config/WebConfig.java
@@ -11,7 +11,11 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins("http://localhost:3000", "https://welper.store") // 프론트 주소
+                .allowedOrigins(
+                        "https://api.welper.store",
+                        "https://www.api.welper.store",
+                        "https://welper.store",
+                        "http://localhost:8080)")// 프론트, 백엔드 등 cors 허용 주소
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowCredentials(true)
                 .maxAge(3600);


### PR DESCRIPTION
CROS Allow-origin 주소 추가하였습니다. 전역 설정인 WebConfig의 alloworigins의 배포주소가 누락되어 일어난 케이스로 보여 수정 및 테스트 하였습니다.