### PR TITLE
Feat : 1차 사정 API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-web-services'
 
+    // ✅ WebClient (reactive HTTP client) 용
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+
     // Swagger UI (OpenAPI 3)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     

--- a/src/main/java/com/example/welperback/controller/ai/AssessmentAiController.java
+++ b/src/main/java/com/example/welperback/controller/ai/AssessmentAiController.java
@@ -1,0 +1,99 @@
+package com.example.welperback.controller.ai;
+
+import com.example.welperback.dto.ai.AiAssessmentSaveRequest;
+import com.example.welperback.dto.ai.AiAssessmentStatusResponse;
+import com.example.welperback.dto.ai.AssessmentAiRequestDto;
+import com.example.welperback.global.response.ApiResponse;
+import com.example.welperback.service.ai.AssessmentAiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/ai/assessments")
+@RequiredArgsConstructor
+public class AssessmentAiController {
+
+    private final AssessmentAiService aiService;
+
+    /**
+     * 2번: AI 분석 요청
+     */
+    @PostMapping("/request")
+    public ApiResponse<?> requestAiAssessment(
+            @RequestBody AssessmentAiRequestDto requestDto
+    ) {
+
+        var result = aiService.startAiAssessment(requestDto);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("requestId", result.requestId());
+        data.put("status", result.status());
+        data.put("message", result.message());
+
+        return ApiResponse.success(
+                "AI 분석 요청을 정상적으로 처리했습니다.",
+                data
+        );
+    }
+
+    /**
+     * 3번: AI 분석 결과 조회 (Polling)
+     */
+    @GetMapping("/result/{requestId}")
+    public ApiResponse<?> getAiAssessmentResult(
+            @PathVariable String requestId
+    ) {
+
+        AiAssessmentStatusResponse statusResponse = aiService.getAssessmentStatus(requestId);
+
+        // NOT_FOUND 처리
+        if ("NOT_FOUND".equals(statusResponse.getStatus())) {
+            return ApiResponse.error(
+                    statusResponse.getMessage(),
+                    404,
+                    null
+            );
+        }
+        Map<String, Object> data = new HashMap<>();
+        data.put("status", statusResponse.getStatus());
+        data.put("message", statusResponse.getMessage());
+        data.put("assessment", statusResponse.getAssessment()); // PROCESSING이면 null
+
+        return ApiResponse.success(
+                "AI 분석 결과 조회를 성공했습니다.",
+                data
+        );
+
+    }
+
+    // 4번: AI 사정 결과 DB 저장
+    @PostMapping("/result/save")
+    public ApiResponse<?> saveAiAssessment(
+            @RequestBody AiAssessmentSaveRequest request
+    ) {
+
+        // 간단 필수값 체크 (정제는 나중에 Bean Validation 써도 됨)
+        if (request.getCaseNumber() == null || request.getCaseNumber().isBlank()) {
+            return ApiResponse.error("필수 필드 누락: caseNumber", 400, null);
+        }
+        if (request.getAssessmentDate() == null) {
+            return ApiResponse.error("필수 필드 누락: assessmentDate", 400, null);
+        }
+        if (request.getType() == null || request.getType().isBlank()) {
+            return ApiResponse.error("필수 필드 누락: type", 400, null);
+        }
+
+        String recordId = aiService.saveAiAssessment(request);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("assessmentRecordId", recordId);
+
+        return ApiResponse.success(
+                "AI 사정 결과를 저장했습니다.",
+                data
+        );
+    }
+}

--- a/src/main/java/com/example/welperback/controller/file/FileController.java
+++ b/src/main/java/com/example/welperback/controller/file/FileController.java
@@ -1,0 +1,20 @@
+package com.example.welperback.controller.file;
+
+import com.example.welperback.dto.file.response.VoiceUploadResponse;
+import com.example.welperback.service.file.FileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/files")
+@RequiredArgsConstructor
+public class FileController {
+
+    private final FileService fileService;
+
+    @PostMapping("/voice")
+    public VoiceUploadResponse uploadVoice(@RequestParam("file") MultipartFile file) throws Exception {
+        return fileService.uploadVoice(file);
+    }
+}

--- a/src/main/java/com/example/welperback/domain/assessment/AssessmentRecord.java
+++ b/src/main/java/com/example/welperback/domain/assessment/AssessmentRecord.java
@@ -4,6 +4,8 @@ import com.example.welperback.domain.client.Client;
 import com.example.welperback.global.jpa.JsonMapConverter;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDate;
 import java.util.Map;
@@ -32,8 +34,10 @@ public class AssessmentRecord {
     private String ecomapFilePath;
     private String voiceRecordFilePath;
 
-    @Convert(converter = JsonMapConverter.class)
-    @Column(columnDefinition = "jsonb")
+    // ✅ 여기: Converter 제거하고 JSON 타입으로 매핑
+    @JdbcTypeCode(SqlTypes.JSON)              // Hibernate에게 "이 필드는 JSON이야"라고 알려줌
+    @Column(name = "checklist_data",
+            columnDefinition = "jsonb")       // 실제 DB 컬럼은 jsonb 유지
     private Map<String, Object> checklistData;
 
     private String produceStatus; // PRODUCING, COMPLETE

--- a/src/main/java/com/example/welperback/dto/ai/AiAssessmentResponse.java
+++ b/src/main/java/com/example/welperback/dto/ai/AiAssessmentResponse.java
@@ -1,0 +1,7 @@
+package com.example.welperback.dto.ai;
+
+public record AiAssessmentResponse(
+        String requestId,
+        String status,
+        String message
+) {}

--- a/src/main/java/com/example/welperback/dto/ai/AiAssessmentSaveRequest.java
+++ b/src/main/java/com/example/welperback/dto/ai/AiAssessmentSaveRequest.java
@@ -1,0 +1,50 @@
+package com.example.welperback.dto.ai;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AiAssessmentSaveRequest {
+
+    // === 어떤 클라이언트(사례)에 대한 사정인지 ===
+    private String caseNumber;           // ★ 이걸로 Client 찾을 거야
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate assessmentDate;    // 2025-01-20
+
+    private String type;                 // NEW, REASSESSMENT
+    private String managerId;            // 담당자 기록용(지금은 AssessmentRecord에 직접 FK 없으니까 로그 느낌)
+
+    // === 파일 / 음성 경로 (지금은 단순 String) ===
+    private String genogramFileId;       // -> genogramFilePath
+    private String ecomapFileId;         // -> ecomapFilePath
+    private String voiceRecordFileUrl;   // -> voiceRecordFilePath
+
+    /**
+     * checklistData 전체:
+     *  - meetingLogs
+     *  - clientProfile
+     *  - emergencyContact
+     *  - householdType
+     *  - disabilityStatus
+     *  - longTermCareStatus
+     *  - housingStatus
+     *  - familyMembers
+     *  - needsAssessmentRecord
+     *  - scaleAssessments
+     *  - assessmentOutcome
+     *
+     * 그대로 AssessmentRecord.checklistData(jsonb)에 넣을 거야.
+     */
+    private Map<String, Object> checklistData;
+
+    // === AI가 생성한 텍스트 요약 ===
+    private String strengthsAndResources;   // 강점·자원
+    private String comprehensiveOpinion;    // 종합의견
+}

--- a/src/main/java/com/example/welperback/dto/ai/AiAssessmentStatusResponse.java
+++ b/src/main/java/com/example/welperback/dto/ai/AiAssessmentStatusResponse.java
@@ -1,0 +1,25 @@
+package com.example.welperback.dto.ai;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiAssessmentStatusResponse {
+
+    // PROCESSING / FINISHED
+    private String status;
+
+    // PROCESSING일 때: "AI가 음성 분석을 진행 중입니다."
+    // FINISHED일 때: null 가능
+    private String message;
+
+    // FINISHED일 때만 채워지는 평가 결과 전체 JSON
+    private Map<String, Object> assessment;
+}

--- a/src/main/java/com/example/welperback/dto/ai/AssessmentAiRequestDto.java
+++ b/src/main/java/com/example/welperback/dto/ai/AssessmentAiRequestDto.java
@@ -1,0 +1,27 @@
+package com.example.welperback.dto.ai;
+
+import java.util.List;
+
+public record AssessmentAiRequestDto(
+        String caseNumber,
+        String socialWorkerId,
+        String voiceFileUrl,
+        IntakeData intakeData
+) {
+    public record IntakeData(
+            String assignedSocialWorkerName,
+            String interviewDate,
+            int sessionNumber,
+            String referralSource,
+            String clientName,
+            String gender,
+            List<FamilyMember> familyMembers,
+            String needsDescription,
+            String intakeResult
+    ) {}
+
+    public record FamilyMember(
+            String relationship,
+            String name
+    ) {}
+}

--- a/src/main/java/com/example/welperback/dto/file/response/VoiceUploadResponse.java
+++ b/src/main/java/com/example/welperback/dto/file/response/VoiceUploadResponse.java
@@ -1,0 +1,11 @@
+package com.example.welperback.dto.file.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class VoiceUploadResponse {
+    private String filePath;
+    private String fileName;
+}

--- a/src/main/java/com/example/welperback/global/config/WebClientConfig.java
+++ b/src/main/java/com/example/welperback/global/config/WebClientConfig.java
@@ -1,0 +1,18 @@
+package com.example.welperback.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient aiWebClient() {
+        return WebClient.builder()
+                // ✅ AI 서버 주소 (나중에 실제 주소로 바꾸면 됨)
+                .baseUrl("http://localhost:5000")
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+}

--- a/src/main/java/com/example/welperback/global/config/WebConfig.java
+++ b/src/main/java/com/example/welperback/global/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.example.welperback.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -23,4 +24,6 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true)
                 .maxAge(3600);
     }
+
 }
+

--- a/src/main/java/com/example/welperback/global/exception/CustomException.java
+++ b/src/main/java/com/example/welperback/global/exception/CustomException.java
@@ -1,6 +1,7 @@
 package com.example.welperback.global.exception;
-// 커스텀 런타임 예외 처리 클래스
+
 public class CustomException extends RuntimeException {
+
     private final ErrorCode errorCode;
 
     public CustomException(ErrorCode errorCode) {

--- a/src/main/java/com/example/welperback/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/welperback/global/exception/ErrorCode.java
@@ -1,19 +1,11 @@
 package com.example.welperback.global.exception;
 
 import org.springframework.http.HttpStatus;
-// 에러코드 enum
-public enum ErrorCode {
-    // 400
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
-    TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "토큰이 만료되었습니다."),
 
-    FORBIDDEN(HttpStatus.UNAUTHORIZED, "해당 요청에 대한 권한이 없습니다."),
-    CLIENT_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 클라이언트입니다."),
-    // 500
+public enum ErrorCode {
+
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다.");
 
     private final HttpStatus status;
@@ -24,11 +16,10 @@ public enum ErrorCode {
         this.message = message;
     }
 
-    public HttpStatus getStatus() {
-        return status;
-    }
+    public HttpStatus getStatus() { return status; }
+    public String getMessage() { return message; }
 
-    public String getMessage() {
-        return message;
+    public Object getDetails() {
+        return null; // 필요 없을 때
     }
 }

--- a/src/main/java/com/example/welperback/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/welperback/global/exception/GlobalExceptionHandler.java
@@ -7,31 +7,57 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-//@RestControllerAdvice
+import java.util.Map;
+
+@RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    /**
+     * ✔ CustomException 처리
+     */
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<Object>> handleCustomException(CustomException e) {
+
         ErrorCode errorCode = e.getErrorCode();
+
         return ResponseEntity
                 .status(errorCode.getStatus())
-                .body(ApiResponse.error(errorCode.getMessage(), errorCode.getStatus().value()));
+                .body(ApiResponse.error(
+                        errorCode.getMessage(),
+                        errorCode.getStatus().value(),
+                        errorCode.getDetails()
+                ));
     }
 
+    /**
+     * ✔ 모든 예기치 못한 오류 처리
+     */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Object>> handleGeneralException(Exception e, HttpServletRequest request) throws Exception {
+    public ResponseEntity<ApiResponse<Object>> handleGeneralException(
+            Exception e,
+            HttpServletRequest request
+    ) {
+
         String uri = request.getRequestURI();
 
-        // ✅ Swagger, API Docs 요청은 전역 예외처리 대상에서 제외
+        // Swagger 요청은 제외
         if (uri.startsWith("/v3/api-docs") ||
-                uri.startsWith("/swagger-ui") ||
-                uri.startsWith("/swagger")) {
-            throw e;  // Springdoc이 직접 처리하도록 다시 던짐
+                uri.startsWith("/swagger") ||
+                uri.startsWith("/swagger-ui")) {
+            throw new RuntimeException(e);
         }
 
         e.printStackTrace();
+
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error("서버 내부 오류가 발생했습니다.", 500));
+                .body(ApiResponse.error(
+                        "서버 내부 오류가 발생했습니다.",
+                        500,
+                        Map.of(
+                                "type", e.getClass().getSimpleName(),
+                                "message", e.getMessage()
+                        )
+                ));
     }
 }

--- a/src/main/java/com/example/welperback/global/jpa/JsonMapConverter.java
+++ b/src/main/java/com/example/welperback/global/jpa/JsonMapConverter.java
@@ -1,32 +1,41 @@
 package com.example.welperback.global.jpa;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
-@Converter
+@Converter(autoApply = false)  // autoApply = false 권장
 public class JsonMapConverter implements AttributeConverter<Map<String, Object>, String> {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public String convertToDatabaseColumn(Map<String, Object> attribute) {
-        try {
-            return objectMapper.writeValueAsString(attribute);
-        } catch (Exception e) {
+        if (attribute == null || attribute.isEmpty()) {
             return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(attribute); // 순수 JSON 문자열
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to convert Map to JSON String", e);
         }
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Map<String, Object> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return new HashMap<>();
+        }
         try {
-            return objectMapper.readValue(dbData, new TypeReference<>() {});
-        } catch (Exception e) {
-            return null;
+            return objectMapper.readValue(dbData, Map.class);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to convert JSON String to Map", e);
         }
     }
 }

--- a/src/main/java/com/example/welperback/global/response/ApiResponse.java
+++ b/src/main/java/com/example/welperback/global/response/ApiResponse.java
@@ -1,32 +1,32 @@
 package com.example.welperback.global.response;
 
 public class ApiResponse<T> {
+
+    private final boolean success;
     private final String message;
     private final int code;
     private final T data;
+    private final Object error;
 
-    private ApiResponse(String message, int code, T data) {
+    private ApiResponse(boolean success, String message, int code, T data, Object error) {
+        this.success = success;
         this.message = message;
         this.code = code;
         this.data = data;
+        this.error = error;
     }
 
     public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(message,200,data);
-    }
-    public static <T> ApiResponse<T> error(String message, int code) {
-        return new ApiResponse<>(message,code,null);
+        return new ApiResponse<>(true, message, 200, data, null);
     }
 
-    public String getMessage() {
-        return message;
+    public static <T> ApiResponse<T> error(String message, int code, Object errorDetails) {
+        return new ApiResponse<>(false, message, code, null, errorDetails);
     }
 
-    public int getCode() {
-        return code;
-    }
-
-    public T getData() {
-        return data;
-    }
+    public boolean isSuccess() { return success; }
+    public String getMessage() { return message; }
+    public int getCode() { return code; }
+    public T getData() { return data; }
+    public Object getError() { return error; }
 }

--- a/src/main/java/com/example/welperback/repository/AssessmentRecordRepository.java
+++ b/src/main/java/com/example/welperback/repository/AssessmentRecordRepository.java
@@ -1,0 +1,7 @@
+package com.example.welperback.repository;
+
+import com.example.welperback.domain.assessment.AssessmentRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AssessmentRecordRepository extends JpaRepository<AssessmentRecord, String> {
+}

--- a/src/main/java/com/example/welperback/repository/ClientRepository.java
+++ b/src/main/java/com/example/welperback/repository/ClientRepository.java
@@ -1,0 +1,8 @@
+package com.example.welperback.repository;
+
+import com.example.welperback.domain.client.Client;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClientRepository extends JpaRepository<Client, String> {
+    // caseNumber가 PK인 경우 이대로 사용
+}

--- a/src/main/java/com/example/welperback/repository/IntakeRecordRepository.java
+++ b/src/main/java/com/example/welperback/repository/IntakeRecordRepository.java
@@ -1,0 +1,4 @@
+package com.example.welperback.repository;
+
+public class IntakeRecordRepository {
+}

--- a/src/main/java/com/example/welperback/service/ai/AssessmentAiService.java
+++ b/src/main/java/com/example/welperback/service/ai/AssessmentAiService.java
@@ -1,0 +1,245 @@
+package com.example.welperback.service.ai;
+
+import com.example.welperback.domain.assessment.AssessmentRecord;
+import com.example.welperback.domain.client.Client;
+import com.example.welperback.dto.ai.AiAssessmentSaveRequest;
+import com.example.welperback.dto.ai.AiAssessmentStatusResponse;
+import com.example.welperback.dto.ai.AssessmentAiRequestDto;
+import com.example.welperback.repository.AssessmentRecordRepository;
+import com.example.welperback.repository.ClientRepository;
+import com.example.welperback.service.ai.polling.PollingStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AssessmentAiService {
+
+    private final PollingStore pollingStore;
+    private final AssessmentRecordRepository assessmentRecordRepository;
+    private final ClientRepository clientRepository;
+
+    // 2번 API 응답용
+    public record AiRequestInit(
+            String requestId,
+            String status,
+            String message
+    ) {}
+
+    // =========================
+    // 2번: AI 분석 요청 시작
+    // =========================
+    public AiRequestInit startAiAssessment(AssessmentAiRequestDto dto) {
+        String requestId = "REQ-" + UUID.randomUUID().toString().substring(0, 8);
+        pollingStore.init(requestId);
+
+        return new AiRequestInit(
+                requestId,
+                "PROCESSING",
+                "AI 분석을 시작했습니다."
+        );
+    }
+
+    // =========================
+    // 3번: AI 분석 결과 조회 (Polling)
+    //  - 지금 잘 돌아가고 있으니까 그대로 유지
+    // =========================
+    public AiAssessmentStatusResponse getAssessmentStatus(String requestId) {
+
+        var status = pollingStore.get(requestId);
+        if (status == null) {
+            return AiAssessmentStatusResponse.builder()
+                    .status("NOT_FOUND")
+                    .message("해당 요청 ID를 찾을 수 없습니다.")
+                    .assessment(null)
+                    .build();
+        }
+
+        pollingStore.increaseProgress(requestId);
+        var updated = pollingStore.get(requestId);
+
+        if (!"FINISHED".equals(updated.state())) {
+            return AiAssessmentStatusResponse.builder()
+                    .status("PROCESSING")
+                    .message("AI가 음성 분석을 진행 중입니다.")
+                    .assessment(null)
+                    .build();
+        }
+
+        Map<String, Object> assessment = buildMockAssessment();
+
+        return AiAssessmentStatusResponse.builder()
+                .status("FINISHED")
+                .message(null)
+                .assessment(assessment)
+                .build();
+    }
+
+    // =========================
+    // 4번: AI 사정 결과 DB 저장
+    // =========================
+    public String saveAiAssessment(AiAssessmentSaveRequest dto) {
+
+        // 1) caseNumber로 Client 찾기
+        Client client = clientRepository.findById(dto.getCaseNumber())
+                .orElseThrow(() ->
+                        new IllegalArgumentException("존재하지 않는 사례번호입니다: " + dto.getCaseNumber())
+                );
+        // → 나중에 CustomException + ErrorCode.CLIENT_NOT_FOUND로 바꿔도 됨
+
+        // 2) recordId 생성
+        String recordId = "AR-" + UUID.randomUUID().toString().substring(0, 8);
+
+        // 3) 엔티티 빌드
+        AssessmentRecord record = AssessmentRecord.builder()
+                .recordId(recordId)
+                .client(client)  // ★ 연관관계 주입
+                .assessmentDate(dto.getAssessmentDate())
+                .type(dto.getType())
+
+                .genogramFilePath(dto.getGenogramFileId())
+                .ecomapFilePath(dto.getEcomapFileId())
+                .voiceRecordFilePath(dto.getVoiceRecordFileUrl())
+
+                .checklistData(dto.getChecklistData())  // ★ 전체 assessment JSON 통으로 저장
+                .produceStatus("COMPLETE")
+
+                .strengthsAndResources(dto.getStrengthsAndResources())
+                .comprehensiveOpinion(dto.getComprehensiveOpinion())
+                .build();
+
+        // 4) 저장
+        AssessmentRecord saved = assessmentRecordRepository.save(record);
+
+        return saved.getRecordId();
+    }
+
+
+    // ======================================================
+    // 3번 API 완성 응답용 Mock 데이터
+    // → 여기가 data.assessment에 그대로 들어가는 JSON 구조
+    // ======================================================
+    private Map<String, Object> buildMockAssessment() {
+
+        // 최상위 assessment 객체
+        Map<String, Object> root = new LinkedHashMap<>();
+
+        root.put("clientName", "김철수");
+        root.put("managerName", "홍길동");
+        root.put("caseNumber", "CASE-2025-001");
+        root.put("assessmentDate", "2025-01-20");
+        root.put("assessmentType", "NEW");
+
+        // meetingLogs 배열
+        Map<String, Object> meetingLog = new LinkedHashMap<>();
+        meetingLog.put("date", "2025-01-20T14:00:00Z");
+        meetingLog.put("method", "대면");
+        meetingLog.put("interviewer", "홍길동");
+        meetingLog.put("interviewee", "김철수");
+        root.put("meetingLogs", List.of(meetingLog));
+
+        // clientProfile
+        Map<String, Object> clientProfile = new LinkedHashMap<>();
+        clientProfile.put("birthDate", "1984-03-15");
+        clientProfile.put("gender", "MALE");
+        clientProfile.put("occupation", "무직");
+        clientProfile.put("address", "서울시 강북구");
+        clientProfile.put("phoneNumber", "010-1234-5678");
+        clientProfile.put("protectionType", List.of("LIVELIHOOD"));
+        root.put("clientProfile", clientProfile);
+
+        // emergencyContact
+        Map<String, Object> emergencyContact = new LinkedHashMap<>();
+        emergencyContact.put("name", "이영희");
+        emergencyContact.put("relationship", "모");
+        emergencyContact.put("phoneNumber", "010-9999-1234");
+        root.put("emergencyContact", emergencyContact);
+
+        // householdType
+        root.put("householdType", "SINGLE");
+
+        // disabilityStatus (null 값 있으므로 Map.of() 쓰지 말 것!)
+        Map<String, Object> disabilityStatus = new LinkedHashMap<>();
+        disabilityStatus.put("hasDisability", false);
+        disabilityStatus.put("type", null);
+        disabilityStatus.put("grade", null);
+        root.put("disabilityStatus", disabilityStatus);
+
+        // longTermCareStatus (null 값 포함)
+        Map<String, Object> longTermCareStatus = new LinkedHashMap<>();
+        longTermCareStatus.put("hasCare", false);
+        longTermCareStatus.put("grade", null);
+        longTermCareStatus.put("gradeDetail", null);
+        root.put("longTermCareStatus", longTermCareStatus);
+
+        // housingStatus
+        Map<String, Object> housingStatus = new LinkedHashMap<>();
+        housingStatus.put("houseType", "HOUSE_MULTI");
+        housingStatus.put("ownershipType", "MONTHLY_RENT");
+        housingStatus.put("monthlyRent", 350000);
+        root.put("housingStatus", housingStatus);
+
+        // familyMembers 배열
+        Map<String, Object> familyMember = new LinkedHashMap<>();
+        familyMember.put("relationship", "mother");
+        familyMember.put("name", "이영희");
+        familyMember.put("gender", "FEMALE");
+        familyMember.put("birthDate", "1960-04-02");
+        familyMember.put("age", 65);
+        familyMember.put("job", "무직");
+        familyMember.put("isCohabiting", true);
+        familyMember.put("note", "의료 필요");
+        root.put("familyMembers", List.of(familyMember));
+
+        // 파일 ID
+        root.put("genogramFileId", "file_genogram_123");
+        root.put("ecomapFileId", "file_ecomap_123");
+
+        // needsAssessmentRecord 배열
+        Map<String, Object> needs1 = new LinkedHashMap<>();
+        needs1.put("category", "ECONOMIC");
+        needs1.put("narrativeAssessment", "경제적 어려움이 지속되고 있음");
+        needs1.put("needsLevel", 3);
+        needs1.put("priorityRank", 1);
+
+        Map<String, Object> needs2 = new LinkedHashMap<>();
+        needs2.put("category", "HEALTH");
+        needs2.put("narrativeAssessment", "우울 및 불안 증상이 관찰됨");
+        needs2.put("needsLevel", 2);
+        needs2.put("priorityRank", 2);
+
+        root.put("needsAssessmentRecord", List.of(needs1, needs2));
+
+        // scaleAssessments 배열
+        Map<String, Object> scale1 = new LinkedHashMap<>();
+        scale1.put("scaleName", "PHQ-9");
+        scale1.put("scaleScore", "중등도 우울 (15점)");
+        scale1.put("note", "정신건강센터 연계 필요");
+
+        Map<String, Object> scale2 = new LinkedHashMap<>();
+        scale2.put("scaleName", "GAD-7");
+        scale2.put("scaleScore", "중등도 불안 (13점)");
+        scale2.put("note", null);
+
+        root.put("scaleAssessments", List.of(scale1, scale2));
+
+        // assessmentOutcome
+        Map<String, Object> assessmentOutcome = new LinkedHashMap<>();
+        assessmentOutcome.put("topPriorityNeeds",
+                List.of("경제적 안정", "정서적 안정", "주거 안전성 확보"));
+        assessmentOutcome.put("clientWants", "경제 지원과 주거 문제 해결 요청");
+        assessmentOutcome.put("assessedNeeds", "경제·정서적 문제가 주요 위험 요인으로 판단됨");
+        assessmentOutcome.put("strengthsAndResources", "가족 지지 강함, 지역사회 네트워크 일부 존재");
+        assessmentOutcome.put("limitationsAndBarriers", "정서적 불안정과 지속적 무직 상태로 인한 동기 저하");
+        assessmentOutcome.put("comprehensiveOpinion", "경제적 개입 + 정신건강 지원 동시 필요");
+        assessmentOutcome.put("caseManagementLevel", "GENERAL");
+        root.put("assessmentOutcome", assessmentOutcome);
+
+        return root;
+    }
+}

--- a/src/main/java/com/example/welperback/service/ai/polling/PollingStore.java
+++ b/src/main/java/com/example/welperback/service/ai/polling/PollingStore.java
@@ -1,0 +1,34 @@
+package com.example.welperback.service.ai.polling;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
+
+//AiPollingService 는 지금은 안 써도 돼. 나중에 진짜 AI 서버 붙일 때 여기 PollingStore 대신 WebClient 호출로 갈아끼우면 됨.
+@Component
+public class PollingStore {
+
+    // requestId -> 상태 저장
+    private final Map<String, PollingStatus> store = new ConcurrentHashMap<>();
+
+    public void init(String requestId) {
+        store.put(requestId, new PollingStatus(0, "PROCESSING"));
+    }
+
+    public PollingStatus get(String requestId) {
+        return store.get(requestId);
+    }
+
+    public void increaseProgress(String requestId) {
+        PollingStatus status = store.get(requestId);
+        if (status == null) return;
+
+        int newProgress = Math.min(status.progress() + 25, 100);
+        String newState = (newProgress >= 100) ? "FINISHED" : "PROCESSING";
+
+        store.put(requestId, new PollingStatus(newProgress, newState));
+    }
+
+    public record PollingStatus(int progress, String state) {}
+}

--- a/src/main/java/com/example/welperback/service/file/FileService.java
+++ b/src/main/java/com/example/welperback/service/file/FileService.java
@@ -1,0 +1,43 @@
+package com.example.welperback.service.file;
+
+import com.example.welperback.dto.file.response.VoiceUploadResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.*;
+
+import java.util.UUID;
+
+@Service
+public class FileService {
+
+    private String getUploadDir() {
+        String os = System.getProperty("os.name").toLowerCase();
+
+        if (os.contains("mac")) {
+            return System.getProperty("user.home") + "/welper-uploads";
+        } else if (os.contains("win")) {
+            return System.getProperty("user.home") + "\\welper-uploads";
+        } else {
+            return "/home/welper/uploads";
+        }
+    }
+
+    public VoiceUploadResponse uploadVoice(MultipartFile file) throws IOException {
+
+        String baseDir = getUploadDir();
+        Files.createDirectories(Paths.get(baseDir));
+
+        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        Path path = Paths.get(baseDir, fileName);
+
+        Files.write(path, file.getBytes());
+        System.out.println("UPLOAD DIR = " + getUploadDir());
+
+        return VoiceUploadResponse.builder()
+                .filePath(path.toString())
+                .fileName(fileName)
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,13 @@ spring:
     username: "welper"
     password: ${DB_LOCAL_PASSWORD}
     driver-class-name: org.postgresql.Driver
+  # 멀티 폼데이터를 처리하기 위해 하는 것
+  # 스프링 부트 3.x 버전부터 자동 enable이 아니라 따로 설정해줘야함
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 50MB
+      max-request-size: 50MB
 
 ---
 # ==================================================================


### PR DESCRIPTION
# 🔍 What is the PR?

* **AI 음성 분석 처리 흐름(2~4번) 백엔드 구현**
* **AI 서버와의 비동기 구조 (Request → Polling → Save) 완성**
* **AssessmentRecord 저장 API 구축**
* **JsonMapConverter 개선 (jsonb 타입 직렬화 이슈 해결)**
* **Mock 기반 로컬 테스트 흐름 구축**

---

## 🚀 구현 상세

### **1) AI 분석 요청 시작 API (2번)**

`POST /api/v1/ai/assessments/request`

* AI 서버에 음성 분석을 시작하도록 요청
* 현재는 Mock 방식으로 **requestId 생성 후 PollingStore에 PROCESSING 저장**
* 실제 AI 서버 연동 시 WebClient로 쉽게 교체 가능하게 설계

**Response 예시**

```json
{
  "requestId": "REQ-f92a0a1c",
  "status": "PROCESSING",
  "message": "AI 분석을 시작했습니다."
}
```

---

### **2) AI 분석 결과 폴링 API (3번)**

`GET /api/v1/ai/assessments/result/{requestId}`

* 백엔드 → AI 서버의 진행 여부를 반복 확인하는 구조
* Mock 로직:

  * 매 요청마다 progress 증가
  * 특정 시점에서 FINISHED로 전환
  * FINISHED 시 정해진 AI 분석 JSON을 그대로 리턴

**구현 포인트**

* PollingStore 내부에서 상태 관리
* 실제 AI 서버로 교체 시 WebClient 호출만 변경하면 됨
* FINISHED 시 아래 형태로 응답

```json
{
  "success": true,
  "data": {
    "status": "FINISHED",
    "assessment": { ...AI 분석 결과 전체 JSON... }
  }
}
```

---

### **3) AI 분석 결과 저장 API (4번)**

`POST /api/v1/ai/assessments/save`

* 3번 API에서 받은 **AI 분석 JSON 전체를 DB에 저장**
* 저장 위치: `AssessmentRecord.checklistData (jsonb)`
* DB 저장 필드

  * checklistData(JSONB)
  * strengthsAndResources
  * comprehensiveOpinion
  * voiceRecordFilePath
  * genogram/ecomap 파일 경로 등

**핵심 개선**

* PostgreSQL JSONB 저장 시 발생한 bytea 문제 해결
  → JsonMapConverter를 Jackson 기반 문자열 직렬화/역직렬화 방식으로 수정
  → 정상적으로 jsonb 타입에 저장됨

---

## 📦 주요 개발 포인트

### **🔧 JsonMapConverter 안정화**

* 기존: GZIP 압축 방식 → PostgreSQL jsonb에 bytea로 저장되어 오류
* 변경: Jackson ObjectMapper 기반 문자열 변환
* 결과: 모든 Map<String, Object>가 정상적으로 jsonb로 저장됨

### **🧪 Mock 기반 로컬 테스트 수립**

* 실제 AI 서버 없이 전체 흐름 테스트 가능
* 프론트도 즉시 연동 가능

흐름:

```
2번 요청 START → requestId 발급
↓  
3번 RESULT 폴링 → FINISHED 감지
↓
4번 SAVE API 호출 → DB 저장 완료
```

---

## 📍 PR Point

* **AI 서버 없이도 전체 흐름을 테스트할 수 있는 Mock 아키텍처 완성**
* **AI 분석 결과를 완전한 JSON 그대로 저장하는 구조 확립**
* **JsonMapConverter 개선으로 안정적 JSONB 저장**
* **AssessmentRecord와 Client 연동**
  → caseNumber 기준으로 참조 저장 가능
* **확장성 있는 Polling 구조 구성**

앞으로 실제 AI 서버를 연결하면,

* WebClient 호출부만 교체하면 전체 로직 그대로 재사용 가능함

---

## 📢 Notices

* 현재 AI 분석 결과는 Mock 데이터
* 추후 실제 Python 서버 연결 시 requestId 기준으로 동일한 구조 유지
* 모든 API 응답은 공통 ApiResponse 구조를 따름

---

## ✅ Check List

* [x] Merge 타겟 브랜치 확인
* [x] PR과 관련 없는 파일 변경 없음
* [x] Self-review 완료
* [x] 로컬 테스트 정상 수행

---

## 💭 Related Issues

* `#20`

