### PR TITLE
fix: 중복 로그인 시 refresh token 처리 방식 update형태로 변경

### DIFF
--- a/src/main/java/com/example/welperback/repository/account/RefreshTokenRepository.java
+++ b/src/main/java/com/example/welperback/repository/account/RefreshTokenRepository.java
@@ -2,7 +2,9 @@ package com.example.welperback.repository.account;
 
 import com.example.welperback.domain.account.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -11,7 +13,13 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByToken(String token);
     Optional<RefreshToken> findByUserId(String userId);
+    
+    @Modifying
+    @Transactional
     void deleteByUserId(String userId);
+    
+    @Modifying
+    @Transactional
     void deleteByExpiresAtBefore(LocalDateTime dateTime);
 }
 

--- a/src/main/java/com/example/welperback/service/AuthService.java
+++ b/src/main/java/com/example/welperback/service/AuthService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -267,21 +268,30 @@ public class AuthService {
     }
 
     /**
-     * Refresh Token 저장
+     * Refresh Token 저장 (Upsert 방식)
+     * 기존 토큰이 있으면 업데이트, 없으면 새로 생성
      */
     private void saveRefreshToken(String userId, String token) {
-        // 기존 Refresh Token 삭제
-        refreshTokenRepository.findByUserId(userId)
-                .ifPresent(refreshTokenRepository::delete);
-
-        // 새로운 Refresh Token 저장
-        RefreshToken refreshToken = RefreshToken.builder()
-                .userId(userId)
-                .token(token)
-                .expiresAt(LocalDateTime.now().plusDays(7)) // 7일 후 만료
-                .build();
-
-        refreshTokenRepository.save(refreshToken);
+        LocalDateTime expiresAt = LocalDateTime.now().plusDays(7);
+        
+        // 기존 Refresh Token 조회
+        Optional<RefreshToken> existingToken = refreshTokenRepository.findByUserId(userId);
+        
+        if (existingToken.isPresent()) {
+            // 기존 토큰이 있으면 업데이트
+            RefreshToken refreshToken = existingToken.get();
+            refreshToken.setToken(token);
+            refreshToken.setExpiresAt(expiresAt);
+            refreshTokenRepository.save(refreshToken);
+        } else {
+            // 기존 토큰이 없으면 새로 생성
+            RefreshToken refreshToken = RefreshToken.builder()
+                    .userId(userId)
+                    .token(token)
+                    .expiresAt(expiresAt)
+                    .build();
+            refreshTokenRepository.save(refreshToken);
+        }
     }
 
     /**


### PR DESCRIPTION
## 🔍 What is the PR?

- 로그인 시 refresh token 처리 방식으로 인해 재로그인 불가 문제 발생


## 📍 PR Point

- 로그인 시 refresh token을 update하는 방식으로 수정

## 📢 Notices

- 공용으로 사용하는(Extension) 부분에 대한 설명

## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- 작업한 이슈번호를 # 뒤에 붙여주세요. 

-  #27 
